### PR TITLE
DEV-18456: Add benefitsDescription to user group DTOs

### DIFF
--- a/src/App/CashbackClient.php
+++ b/src/App/CashbackClient.php
@@ -21,6 +21,7 @@ use Dotsplatform\CashbackApi\DTO\Request\Transactions\TransactionsStatisticsDTO;
 use Dotsplatform\CashbackApi\DTO\Request\Transactions\UpdateTransactionNoteDTO;
 use Dotsplatform\CashbackApi\DTO\Request\UserGroups\StoreUserGroupDTO;
 use Dotsplatform\CashbackApi\DTO\Request\UserGroups\StoreUserGroupOrdersSettingsDTO;
+use Dotsplatform\CashbackApi\DTO\Request\UserGroups\UpdateUserGroupTranslationsDTO;
 use Dotsplatform\CashbackApi\DTO\Request\UserGroups\UserGroupsFiltersDTO;
 use Dotsplatform\CashbackApi\DTO\Request\Users\CreateUserDTO;
 use Dotsplatform\CashbackApi\DTO\Request\Users\UpdateUserDTO;
@@ -69,6 +70,8 @@ class CashbackClient extends HttpClient
     private const UPDATE_USER_GROUP_URL_TEMPLATE = '/users-groups/{id}';
     private const DELETE_USER_GROUP_URL_TEMPLATE = '/users-groups/{id}';
     private const UPDATE_USER_GROUP_ORDERS_SETTINGS_URL_TEMPLATE = '/users-groups/{id}/settings/orders';
+
+    private const UPDATE_USER_GROUP_TRANSLATIONS_URL_TEMPLATE = '/users-groups/{id}/translations';
     private const DELETE_USER_GROUPS_URL_TEMPLATE = '/users-groups/accounts/{id}';
     private const DISTRIBUTE_USERS_BETWEEN_GROUPS_URL_TEMPLATE = '/users-groups/accounts/{id}/distribute';
     private const GET_USERS_URL_TEMPLATE = '/users';
@@ -429,6 +432,23 @@ class CashbackClient extends HttpClient
         $response = $this->put(
             $url,
             $data,
+            $params,
+        );
+
+        return ResponseUserGroupDTO::fromArray($response);
+    }
+
+    public function updateUserGroupTranslations(
+        string $userGroupId,
+        UpdateUserGroupTranslationsDTO $dto,
+    ): ResponseUserGroupDTO {
+        $params['json'] = true;
+        $url = $this->parseUrlParams(self::UPDATE_USER_GROUP_TRANSLATIONS_URL_TEMPLATE, [
+            'id' => $userGroupId,
+        ]);
+        $response = $this->put(
+            $url,
+            $dto->toArray(),
             $params,
         );
 

--- a/src/App/DTO/Accounts/AccountSettingsDTO.php
+++ b/src/App/DTO/Accounts/AccountSettingsDTO.php
@@ -101,9 +101,6 @@ class AccountSettingsDTO
         return $this->userGroupsVisible;
     }
 
-    /**
-     * @return array<string, string>
-     */
     public function getLevelMaxText(): array
     {
         return $this->levelMaxText;

--- a/src/App/DTO/Accounts/AccountSettingsDTO.php
+++ b/src/App/DTO/Accounts/AccountSettingsDTO.php
@@ -21,7 +21,7 @@ class AccountSettingsDTO
         private ?string $lang,
         private ?string $cashbackExpirationPeriod,
         private bool $userGroupsVisible = false,
-        private array $levelMaxCaption = [],
+        private array $levelMaxText = [],
     ) {
     }
 
@@ -39,7 +39,7 @@ class AccountSettingsDTO
             $data['lang'] ?? null,
             $data['cashbackExpirationPeriod'] ?? null,
             $data['userGroupsVisible'] ?? false,
-            $data['levelMaxCaption'] ?? [],
+            $data['levelMaxText'] ?? [],
         );
     }
 
@@ -57,7 +57,7 @@ class AccountSettingsDTO
             'lang' => $this->getLang(),
             'cashbackExpirationPeriod' => $this->getCashbackExpirationPeriod(),
             'userGroupsVisible' => $this->isUserGroupsVisible(),
-            'levelMaxCaption' => $this->getLevelMaxCaption(),
+            'levelMaxText' => $this->getLevelMaxText(),
         ];
     }
 
@@ -104,9 +104,9 @@ class AccountSettingsDTO
     /**
      * @return array<string, string>
      */
-    public function getLevelMaxCaption(): array
+    public function getLevelMaxText(): array
     {
-        return $this->levelMaxCaption;
+        return $this->levelMaxText;
     }
 
     public function getCashbackExpirationInterval(): ?int

--- a/src/App/DTO/Accounts/AccountSettingsDTO.php
+++ b/src/App/DTO/Accounts/AccountSettingsDTO.php
@@ -21,6 +21,7 @@ class AccountSettingsDTO
         private ?string $lang,
         private ?string $cashbackExpirationPeriod,
         private bool $usersGroupsVisible = false,
+        private array $levelProgressCaption = [],
     ) {
     }
 
@@ -38,6 +39,7 @@ class AccountSettingsDTO
             $data['lang'] ?? null,
             $data['cashbackExpirationPeriod'] ?? null,
             $data['usersGroupsVisible'] ?? false,
+            $data['levelProgressCaption'] ?? [],
         );
     }
 
@@ -55,6 +57,7 @@ class AccountSettingsDTO
             'lang' => $this->getLang(),
             'cashbackExpirationPeriod' => $this->getCashbackExpirationPeriod(),
             'usersGroupsVisible' => $this->isUsersGroupsVisible(),
+            'levelProgressCaption' => $this->getLevelProgressCaption(),
         ];
     }
 
@@ -96,6 +99,14 @@ class AccountSettingsDTO
     public function isUsersGroupsVisible(): bool
     {
         return $this->usersGroupsVisible;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getLevelProgressCaption(): array
+    {
+        return $this->levelProgressCaption;
     }
 
     public function getCashbackExpirationInterval(): ?int

--- a/src/App/DTO/Accounts/AccountSettingsDTO.php
+++ b/src/App/DTO/Accounts/AccountSettingsDTO.php
@@ -22,6 +22,7 @@ class AccountSettingsDTO
         private ?string $cashbackExpirationPeriod,
         private bool $usersGroupsVisible = false,
         private array $levelProgressCaption = [],
+        private array $levelMaxCaption = [],
     ) {
     }
 
@@ -40,6 +41,7 @@ class AccountSettingsDTO
             $data['cashbackExpirationPeriod'] ?? null,
             $data['usersGroupsVisible'] ?? false,
             $data['levelProgressCaption'] ?? [],
+            $data['levelMaxCaption'] ?? [],
         );
     }
 
@@ -58,6 +60,7 @@ class AccountSettingsDTO
             'cashbackExpirationPeriod' => $this->getCashbackExpirationPeriod(),
             'usersGroupsVisible' => $this->isUsersGroupsVisible(),
             'levelProgressCaption' => $this->getLevelProgressCaption(),
+            'levelMaxCaption' => $this->getLevelMaxCaption(),
         ];
     }
 
@@ -107,6 +110,14 @@ class AccountSettingsDTO
     public function getLevelProgressCaption(): array
     {
         return $this->levelProgressCaption;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getLevelMaxCaption(): array
+    {
+        return $this->levelMaxCaption;
     }
 
     public function getCashbackExpirationInterval(): ?int

--- a/src/App/DTO/Accounts/AccountSettingsDTO.php
+++ b/src/App/DTO/Accounts/AccountSettingsDTO.php
@@ -21,7 +21,6 @@ class AccountSettingsDTO
         private ?string $lang,
         private ?string $cashbackExpirationPeriod,
         private bool $usersGroupsVisible = false,
-        private array $levelProgressCaption = [],
         private array $levelMaxCaption = [],
     ) {
     }
@@ -40,7 +39,6 @@ class AccountSettingsDTO
             $data['lang'] ?? null,
             $data['cashbackExpirationPeriod'] ?? null,
             $data['usersGroupsVisible'] ?? false,
-            $data['levelProgressCaption'] ?? [],
             $data['levelMaxCaption'] ?? [],
         );
     }
@@ -59,7 +57,6 @@ class AccountSettingsDTO
             'lang' => $this->getLang(),
             'cashbackExpirationPeriod' => $this->getCashbackExpirationPeriod(),
             'usersGroupsVisible' => $this->isUsersGroupsVisible(),
-            'levelProgressCaption' => $this->getLevelProgressCaption(),
             'levelMaxCaption' => $this->getLevelMaxCaption(),
         ];
     }
@@ -102,14 +99,6 @@ class AccountSettingsDTO
     public function isUsersGroupsVisible(): bool
     {
         return $this->usersGroupsVisible;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    public function getLevelProgressCaption(): array
-    {
-        return $this->levelProgressCaption;
     }
 
     /**

--- a/src/App/DTO/Accounts/AccountSettingsDTO.php
+++ b/src/App/DTO/Accounts/AccountSettingsDTO.php
@@ -20,7 +20,7 @@ class AccountSettingsDTO
         private ?int $cashbackExpirationInterval,
         private ?string $lang,
         private ?string $cashbackExpirationPeriod,
-        private bool $usersGroupsVisible = false,
+        private bool $userGroupsVisible = false,
         private array $levelMaxCaption = [],
     ) {
     }
@@ -38,7 +38,7 @@ class AccountSettingsDTO
             $data['cashbackExpirationInterval'] ?? null,
             $data['lang'] ?? null,
             $data['cashbackExpirationPeriod'] ?? null,
-            $data['usersGroupsVisible'] ?? false,
+            $data['userGroupsVisible'] ?? false,
             $data['levelMaxCaption'] ?? [],
         );
     }
@@ -56,7 +56,7 @@ class AccountSettingsDTO
             'cashbackExpirationInterval' => $this->getCashbackExpirationInterval(),
             'lang' => $this->getLang(),
             'cashbackExpirationPeriod' => $this->getCashbackExpirationPeriod(),
-            'usersGroupsVisible' => $this->isUsersGroupsVisible(),
+            'userGroupsVisible' => $this->isUserGroupsVisible(),
             'levelMaxCaption' => $this->getLevelMaxCaption(),
         ];
     }
@@ -96,9 +96,9 @@ class AccountSettingsDTO
         return $this->groupsTransitionAvailable;
     }
 
-    public function isUsersGroupsVisible(): bool
+    public function isUserGroupsVisible(): bool
     {
-        return $this->usersGroupsVisible;
+        return $this->userGroupsVisible;
     }
 
     /**

--- a/src/App/DTO/Accounts/AccountSettingsDTO.php
+++ b/src/App/DTO/Accounts/AccountSettingsDTO.php
@@ -20,6 +20,7 @@ class AccountSettingsDTO
         private ?int $cashbackExpirationInterval,
         private ?string $lang,
         private ?string $cashbackExpirationPeriod,
+        private bool $usersGroupsVisible = false,
     ) {
     }
 
@@ -36,6 +37,7 @@ class AccountSettingsDTO
             $data['cashbackExpirationInterval'] ?? null,
             $data['lang'] ?? null,
             $data['cashbackExpirationPeriod'] ?? null,
+            $data['usersGroupsVisible'] ?? false,
         );
     }
 
@@ -52,6 +54,7 @@ class AccountSettingsDTO
             'cashbackExpirationInterval' => $this->getCashbackExpirationInterval(),
             'lang' => $this->getLang(),
             'cashbackExpirationPeriod' => $this->getCashbackExpirationPeriod(),
+            'usersGroupsVisible' => $this->isUsersGroupsVisible(),
         ];
     }
 
@@ -88,6 +91,11 @@ class AccountSettingsDTO
     public function isGroupsTransitionAvailable(): bool
     {
         return $this->groupsTransitionAvailable;
+    }
+
+    public function isUsersGroupsVisible(): bool
+    {
+        return $this->usersGroupsVisible;
     }
 
     public function getCashbackExpirationInterval(): ?int

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -17,7 +17,8 @@ class StoreUserGroupDTO extends DTO
 
     protected ?int $transitionAmount = null;
 
-    protected ?string $benefitsDescription = null;
+    /** @var array<string, string>|null map of language code => description text */
+    protected ?array $benefitsDescription = null;
 
     public function getAccountId(): int
     {
@@ -34,7 +35,10 @@ class StoreUserGroupDTO extends DTO
         return $this->transitionAmount;
     }
 
-    public function getBenefitsDescription(): ?string
+    /**
+     * @return array<string, string>|null
+     */
+    public function getBenefitsDescription(): ?array
     {
         return $this->benefitsDescription;
     }

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -17,7 +17,6 @@ class StoreUserGroupDTO extends DTO
 
     protected ?int $transitionAmount = null;
 
-    /** @var array<string, string>|null map of language code => description text */
     protected ?array $benefitsDescription = null;
 
     public function getAccountId(): int
@@ -35,9 +34,6 @@ class StoreUserGroupDTO extends DTO
         return $this->transitionAmount;
     }
 
-    /**
-     * @return array<string, string>|null
-     */
     public function getBenefitsDescription(): ?array
     {
         return $this->benefitsDescription;

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -33,7 +33,7 @@ class StoreUserGroupDTO extends DTO
         return $this->name;
     }
 
-    public function getTitle(): ?array
+    public function getTitleTranslations(): ?array
     {
         return $this->title;
     }
@@ -43,12 +43,12 @@ class StoreUserGroupDTO extends DTO
         return $this->transitionAmount;
     }
 
-    public function getBenefitsDescription(): ?array
+    public function getBenefitsDescriptionTranslations(): ?array
     {
         return $this->benefitsDescription;
     }
 
-    public function getLevelProgressText(): ?array
+    public function getLevelProgressTextTranslations(): ?array
     {
         return $this->levelProgressText;
     }

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -21,6 +21,8 @@ class StoreUserGroupDTO extends DTO
 
     protected ?array $benefitsDescription = null;
 
+    protected ?array $levelProgressCaption = null;
+
     public function getAccountId(): int
     {
         return $this->accountId;
@@ -44,5 +46,10 @@ class StoreUserGroupDTO extends DTO
     public function getBenefitsDescription(): ?array
     {
         return $this->benefitsDescription;
+    }
+
+    public function getLevelProgressCaption(): ?array
+    {
+        return $this->levelProgressCaption;
     }
 }

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -15,13 +15,13 @@ class StoreUserGroupDTO extends DTO
 
     protected string $name;
 
-    protected ?array $title = null;
+    protected ?array $titleTranslations = null;
 
     protected ?int $transitionAmount = null;
 
-    protected ?array $benefitsDescription = null;
+    protected ?array $benefitsDescriptionTranslations = null;
 
-    protected ?array $levelProgressText = null;
+    protected ?array $levelProgressTextTranslations = null;
 
     public function getAccountId(): int
     {
@@ -35,7 +35,7 @@ class StoreUserGroupDTO extends DTO
 
     public function getTitleTranslations(): ?array
     {
-        return $this->title;
+        return $this->titleTranslations;
     }
 
     public function getTransitionAmount(): ?int
@@ -45,11 +45,11 @@ class StoreUserGroupDTO extends DTO
 
     public function getBenefitsDescriptionTranslations(): ?array
     {
-        return $this->benefitsDescription;
+        return $this->benefitsDescriptionTranslations;
     }
 
     public function getLevelProgressTextTranslations(): ?array
     {
-        return $this->levelProgressText;
+        return $this->levelProgressTextTranslations;
     }
 }

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -21,7 +21,7 @@ class StoreUserGroupDTO extends DTO
 
     protected ?array $benefitsDescription = null;
 
-    protected ?array $levelProgressCaption = null;
+    protected ?array $levelProgressText = null;
 
     public function getAccountId(): int
     {
@@ -48,8 +48,8 @@ class StoreUserGroupDTO extends DTO
         return $this->benefitsDescription;
     }
 
-    public function getLevelProgressCaption(): ?array
+    public function getLevelProgressText(): ?array
     {
-        return $this->levelProgressCaption;
+        return $this->levelProgressText;
     }
 }

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -15,13 +15,7 @@ class StoreUserGroupDTO extends DTO
 
     protected string $name;
 
-    protected ?array $titleTranslations = null;
-
     protected ?int $transitionAmount = null;
-
-    protected ?array $benefitsDescriptionTranslations = null;
-
-    protected ?array $levelProgressTextTranslations = null;
 
     public function getAccountId(): int
     {
@@ -33,23 +27,8 @@ class StoreUserGroupDTO extends DTO
         return $this->name;
     }
 
-    public function getTitleTranslations(): ?array
-    {
-        return $this->titleTranslations;
-    }
-
     public function getTransitionAmount(): ?int
     {
         return $this->transitionAmount;
-    }
-
-    public function getBenefitsDescriptionTranslations(): ?array
-    {
-        return $this->benefitsDescriptionTranslations;
-    }
-
-    public function getLevelProgressTextTranslations(): ?array
-    {
-        return $this->levelProgressTextTranslations;
     }
 }

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -17,6 +17,8 @@ class StoreUserGroupDTO extends DTO
 
     protected ?int $transitionAmount = null;
 
+    protected ?string $benefitsDescription = null;
+
     public function getAccountId(): int
     {
         return $this->accountId;
@@ -30,5 +32,10 @@ class StoreUserGroupDTO extends DTO
     public function getTransitionAmount(): ?int
     {
         return $this->transitionAmount;
+    }
+
+    public function getBenefitsDescription(): ?string
+    {
+        return $this->benefitsDescription;
     }
 }

--- a/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
+++ b/src/App/DTO/Request/UserGroups/StoreUserGroupDTO.php
@@ -15,6 +15,8 @@ class StoreUserGroupDTO extends DTO
 
     protected string $name;
 
+    protected ?array $title = null;
+
     protected ?int $transitionAmount = null;
 
     protected ?array $benefitsDescription = null;
@@ -27,6 +29,11 @@ class StoreUserGroupDTO extends DTO
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getTitle(): ?array
+    {
+        return $this->title;
     }
 
     public function getTransitionAmount(): ?int

--- a/src/App/DTO/Request/UserGroups/UpdateUserGroupTranslationsDTO.php
+++ b/src/App/DTO/Request/UserGroups/UpdateUserGroupTranslationsDTO.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Description of UpdateUserGroupTranslationsDTO.php
+ * @copyright Copyright (c) DOTSPLATFORM, LLC
+ * @author    Bogdan Mamontov <bohdan.mamontov@dotsplatform.com>
+ */
+
+namespace Dotsplatform\CashbackApi\DTO\Request\UserGroups;
+
+use Dots\Data\DTO;
+
+class UpdateUserGroupTranslationsDTO extends DTO
+{
+    protected ?array $titleTranslations = null;
+
+    protected ?array $benefitsDescriptionTranslations = null;
+
+    protected ?array $levelProgressTextTranslations = null;
+
+    public function getTitleTranslations(): ?array
+    {
+        return $this->titleTranslations;
+    }
+
+    public function getBenefitsDescriptionTranslations(): ?array
+    {
+        return $this->benefitsDescriptionTranslations;
+    }
+
+    public function getLevelProgressTextTranslations(): ?array
+    {
+        return $this->levelProgressTextTranslations;
+    }
+}

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -24,7 +24,7 @@ class ResponseUserGroupDTO extends DTO
 
     protected ?array $benefitsDescription = null;
 
-    protected ?array $levelProgressCaption = null;
+    protected ?array $levelProgressText = null;
 
     protected int $usersCount = 0;
 
@@ -67,9 +67,9 @@ class ResponseUserGroupDTO extends DTO
         return $this->benefitsDescription;
     }
 
-    public function getLevelProgressCaption(): ?array
+    public function getLevelProgressText(): ?array
     {
-        return $this->levelProgressCaption;
+        return $this->levelProgressText;
     }
 
     public function getUsersCount(): int

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -24,6 +24,8 @@ class ResponseUserGroupDTO extends DTO
 
     protected ?array $benefitsDescription = null;
 
+    protected ?array $levelProgressCaption = null;
+
     protected int $usersCount = 0;
 
     protected UserGroupSettingsDTO $settings;
@@ -63,6 +65,11 @@ class ResponseUserGroupDTO extends DTO
     public function getBenefitsDescription(): ?array
     {
         return $this->benefitsDescription;
+    }
+
+    public function getLevelProgressCaption(): ?array
+    {
+        return $this->levelProgressCaption;
     }
 
     public function getUsersCount(): int

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -52,7 +52,7 @@ class ResponseUserGroupDTO extends DTO
         return $this->name;
     }
 
-    public function getTitle(): ?array
+    public function getTitleTranslations(): ?array
     {
         return $this->title;
     }
@@ -62,12 +62,12 @@ class ResponseUserGroupDTO extends DTO
         return $this->transitionAmount;
     }
 
-    public function getBenefitsDescription(): ?array
+    public function getBenefitsDescriptionTranslations(): ?array
     {
         return $this->benefitsDescription;
     }
 
-    public function getLevelProgressText(): ?array
+    public function getLevelProgressTextTranslations(): ?array
     {
         return $this->levelProgressText;
     }

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -72,6 +72,21 @@ class ResponseUserGroupDTO extends DTO
         return $this->levelProgressTextTranslations;
     }
 
+    public function getTitle(string $lang): ?string
+    {
+        return $this->titleTranslations[$lang] ?? null;
+    }
+
+    public function getBenefitsDescription(string $lang): ?string
+    {
+        return $this->benefitsDescriptionTranslations[$lang] ?? null;
+    }
+
+    public function getLevelProgressText(string $lang): ?string
+    {
+        return $this->levelProgressTextTranslations[$lang] ?? null;
+    }
+
     public function getUsersCount(): int
     {
         return $this->usersCount;

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -18,6 +18,8 @@ class ResponseUserGroupDTO extends DTO
 
     protected string $name;
 
+    protected ?array $title = null;
+
     protected ?int $transitionAmount;
 
     protected ?array $benefitsDescription = null;
@@ -46,6 +48,11 @@ class ResponseUserGroupDTO extends DTO
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getTitle(): ?array
+    {
+        return $this->title;
     }
 
     public function getTransitionAmount(): ?int

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -20,7 +20,8 @@ class ResponseUserGroupDTO extends DTO
 
     protected ?int $transitionAmount;
 
-    protected ?string $benefitsDescription = null;
+    /** @var array<string, string>|null map of language code => description text */
+    protected ?array $benefitsDescription = null;
 
     protected int $usersCount = 0;
 
@@ -53,7 +54,10 @@ class ResponseUserGroupDTO extends DTO
         return $this->transitionAmount;
     }
 
-    public function getBenefitsDescription(): ?string
+    /**
+     * @return array<string, string>|null
+     */
+    public function getBenefitsDescription(): ?array
     {
         return $this->benefitsDescription;
     }

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -18,13 +18,13 @@ class ResponseUserGroupDTO extends DTO
 
     protected string $name;
 
-    protected ?array $title = null;
+    protected ?array $titleTranslations = null;
 
     protected ?int $transitionAmount;
 
-    protected ?array $benefitsDescription = null;
+    protected ?array $benefitsDescriptionTranslations = null;
 
-    protected ?array $levelProgressText = null;
+    protected ?array $levelProgressTextTranslations = null;
 
     protected int $usersCount = 0;
 
@@ -54,7 +54,7 @@ class ResponseUserGroupDTO extends DTO
 
     public function getTitleTranslations(): ?array
     {
-        return $this->title;
+        return $this->titleTranslations;
     }
 
     public function getTransitionAmount(): ?int
@@ -64,12 +64,12 @@ class ResponseUserGroupDTO extends DTO
 
     public function getBenefitsDescriptionTranslations(): ?array
     {
-        return $this->benefitsDescription;
+        return $this->benefitsDescriptionTranslations;
     }
 
     public function getLevelProgressTextTranslations(): ?array
     {
-        return $this->levelProgressText;
+        return $this->levelProgressTextTranslations;
     }
 
     public function getUsersCount(): int

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -20,6 +20,8 @@ class ResponseUserGroupDTO extends DTO
 
     protected ?int $transitionAmount;
 
+    protected ?string $benefitsDescription = null;
+
     protected int $usersCount = 0;
 
     protected UserGroupSettingsDTO $settings;
@@ -49,6 +51,11 @@ class ResponseUserGroupDTO extends DTO
     public function getTransitionAmount(): ?int
     {
         return $this->transitionAmount;
+    }
+
+    public function getBenefitsDescription(): ?string
+    {
+        return $this->benefitsDescription;
     }
 
     public function getUsersCount(): int

--- a/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
+++ b/src/App/DTO/Response/UserGroups/ResponseUserGroupDTO.php
@@ -20,7 +20,6 @@ class ResponseUserGroupDTO extends DTO
 
     protected ?int $transitionAmount;
 
-    /** @var array<string, string>|null map of language code => description text */
     protected ?array $benefitsDescription = null;
 
     protected int $usersCount = 0;
@@ -54,9 +53,6 @@ class ResponseUserGroupDTO extends DTO
         return $this->transitionAmount;
     }
 
-    /**
-     * @return array<string, string>|null
-     */
     public function getBenefitsDescription(): ?array
     {
         return $this->benefitsDescription;


### PR DESCRIPTION
Thread the new per-level benefits description through the SDK: add the field and getter to the request StoreUserGroupDTO and the response ResponseUserGroupDTO. Serialization is automatic. Requires a 3.8.0 tag before livesite can consume it.